### PR TITLE
using workflow dispatcher to trigger documentation deployment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,4 @@
-on:
-  push:
-    branches:
-      - master
-      # - pipeline 
+on: workflow_dispatch
 
 name: Auto Publish Doc
 jobs:


### PR DESCRIPTION
## Description

using workflow dispatcher to trigger deployment rather than push event. it allows you to control merge and deployment specify. Also you it allow you to 'rollback' deployment.

### constraints: 
- workflow dispatcher can only be trigger on branch  rather than commit

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

