### PR TITLE
index: update golang version requirement

### DIFF
--- a/source/quickstart/quickstart.rst
+++ b/source/quickstart/quickstart.rst
@@ -13,7 +13,7 @@
 
 XuperChain主要由Golang开发，需要首先准备编译运行的环境
 
-- 安装go语言编译环境，版本为1.11或更高
+- 安装go语言编译环境，版本为1.14或更高
     - 下载地址：`golang <https://golang.org/dl/>`_
 - 安装git
     - 下载地址：`git <https://git-scm.com/download>`_

--- a/source/quickstart/quickstart.rst
+++ b/source/quickstart/quickstart.rst
@@ -13,7 +13,7 @@
 
 XuperChain主要由Golang开发，需要首先准备编译运行的环境
 
-- 安装go语言编译环境，版本为1.14或更高
+- 安装go语言编译环境，推荐使用的版本为1.14或1.15
     - 下载地址：`golang <https://golang.org/dl/>`_
 - 安装git
     - 下载地址：`git <https://git-scm.com/download>`_


### PR DESCRIPTION
xuperchain require golang 1.14+ as dependenciy `github.com/consensys/gurvy` no longer support golang older than 1.14

## Description

What is the purpose of the change?
xuperchain require golang 1.14+ as dependenciy github.com/consensys/gurvy no longer support golang older than 1.14

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

